### PR TITLE
Flush producer before committing

### DIFF
--- a/examples/binning/binning.py
+++ b/examples/binning/binning.py
@@ -71,12 +71,12 @@ class Binning(BaseProcessor):
         key = '{},{}'.format(bin_ts.isoformat(), name).encode('utf-8')
 
         if key not in self.store and len(self.store) == 2:
-            self.punctuate()  # TODO need a better way to do that
+            self.punctuate(0)  # TODO need a better way to do that
             self.context.commit()
 
         self.store[key] = price.encode('utf-8')
 
-    def punctuate(self):
+    def punctuate(self, timestamp):
         """Produce output"""
         # TODO: the key is currently symbol/timestamp, we should
         # use a custom partitioner to ensure bins are partitioned by

--- a/examples/debug/example.py
+++ b/examples/debug/example.py
@@ -45,6 +45,7 @@ class DoubleProcessor(BaseProcessor):
             log.debug('Forwarding to sink (%s, %s)', k, v)
             self.context.forward(k, v)
         self.store.clear()
+        self.context.commit()
 
 
 def _debug_run(config_file):

--- a/examples/debug/example.py
+++ b/examples/debug/example.py
@@ -26,6 +26,7 @@ class DoubleProcessor(BaseProcessor):
     def initialise(self, _name, _context):
         super().initialise(_name, _context)
         self.store = self.context.get_store("double-store")
+        self.context.schedule(1)
 
     def process(self, key, value):
         log.debug(f'DoubleProcessor::process({key}, {value})')
@@ -38,16 +39,10 @@ class DoubleProcessor(BaseProcessor):
             return
         self.store.add(key, str(doubled))
 
-        # TODO: In absence of a punctuate call schedule running:
-        if len(self.store) == 4:
-            self.punctuate()
-
-            self.context.commit()
-
-    def punctuate(self):
-        log.debug('DoubleProcessor::punctuate')
+    def punctuate(self, timestamp):
+        log.debug(f'DoubleProcessor::punctuate({timestamp})')
         for k, v in iter(self.store):
-            log.debug('Forwarding to sink  (%s, %s)', k, v)
+            log.debug('Forwarding to sink (%s, %s)', k, v)
             self.context.forward(k, v)
         self.store.clear()
 

--- a/examples/wordcount/example.py
+++ b/examples/wordcount/example.py
@@ -28,9 +28,9 @@ class WordCount(BaseProcessor):
         self.store.update(value.decode('utf-8').split())
 
         # TODO: In absence of a punctuate call schedule running:
-        self.punctuate()
+        self.punctuate(0)
 
-    def punctuate(self):
+    def punctuate(self, timestamp):
         for k, v in self.store.items():
             log.debug('Forwarding to sink  (%s, %s)', k, v)
             self.context.forward(k, str(v))

--- a/tests/processor/test_extract_timestamp.py
+++ b/tests/processor/test_extract_timestamp.py
@@ -10,6 +10,7 @@ import winton_kafka_streams.processor as wks_processor
 
 expected_time = 1496735099.23712
 error_time_offset = 1000
+timestamp_create_time = 1
 
 class TestRecordTimeStampExtractorImpl(wks_processor.RecordTimeStampExtractor):
     def on_error(self, record, timestamp, previous_timestamp):
@@ -20,7 +21,7 @@ class MockRecord:
         self.time = time
 
     def timestamp(self):
-        return self.time
+        return (timestamp_create_time, self.time)
 
 def test_RecordTimeStampExtractorNoImpl():
     pytest.raises(TypeError, wks_processor.RecordTimeStampExtractor)

--- a/tests/processor/test_punctuation_queue.py
+++ b/tests/processor/test_punctuation_queue.py
@@ -1,0 +1,25 @@
+
+import winton_kafka_streams.processor._punctuation_queue as punctuation_queue
+
+def test_punctuation_queue():
+    punctuations = []
+    pq = punctuation_queue.PunctuationQueue(lambda ts, node: punctuations.append((ts, node)))
+    pq.schedule('node', 100)
+    now = -100
+
+    pq.may_punctuate(now)
+    assert len(punctuations) == 0
+
+    pq.may_punctuate(now + 99)
+    assert len(punctuations) == 0
+
+    pq.may_punctuate(now + 100)
+    assert len(punctuations) == 1
+
+    pq.may_punctuate(now + 199)
+    assert len(punctuations) == 1
+
+    pq.may_punctuate(now + 200)
+    assert len(punctuations) == 2
+
+    assert punctuations == [('node', 0), ('node', 100)]

--- a/winton_kafka_streams/kafka_config.py
+++ b/winton_kafka_streams/kafka_config.py
@@ -89,7 +89,7 @@ NUM_STANDBY_REPLICAS = 0
 
 """
 The number of threads to execute stream processing
-Defulat: 1
+Default: 1
 Importance: Medium
 """
 NUM_STREAM_THREADS = 1

--- a/winton_kafka_streams/processor/_punctuation_queue.py
+++ b/winton_kafka_streams/processor/_punctuation_queue.py
@@ -1,0 +1,29 @@
+from queue import PriorityQueue
+from collections import namedtuple
+
+
+PunctuationSchedule = namedtuple('PunctuationSchedule', ['timestamp', 'node', 'interval'])
+
+
+class PunctuationQueue:
+
+    def __init__(self, punctuate):
+        self.pq = PriorityQueue()
+        self.punctuate = punctuate
+
+    def schedule(self, node, interval):
+        self.pq.put(PunctuationSchedule(0, node, interval))
+
+    def may_punctuate(self, timestamp):
+        punctuated = False
+        while not self.pq.empty():
+            top = self.pq.get()
+            if top.timestamp <= timestamp:
+                self.punctuate(top.node, timestamp)
+                punctuated = True
+                next_timestamp = top.interval + (timestamp if top.timestamp == 0 else top.timestamp)
+                self.pq.put(PunctuationSchedule(next_timestamp, top.node, top.interval))
+            else:
+                self.pq.put(top)
+                break
+        return punctuated

--- a/winton_kafka_streams/processor/_stream_thread.py
+++ b/winton_kafka_streams/processor/_stream_thread.py
@@ -121,9 +121,8 @@ class StreamTask:
         # may be asked to commit on rebalance or shutdown but
         # should only commit if the processor has requested.
         if self.commitOffsetNeeded:
-            for ((t, p), o) in self.consumedOffsets.items():
-                self.consumer.commit(offsets=[TopicPartition(t, p, o+1)], async=False)
-
+            offsetsToCommit = [TopicPartition(t, p, o+1) for ((t, p), o) in self.consumedOffsets.items()]
+            self.consumer.commit(offsets=offsetsToCommit, async=False)
             self.consumedOffsets.clear()
             self.commitOffsetNeeded = False
 

--- a/winton_kafka_streams/processor/_stream_thread.py
+++ b/winton_kafka_streams/processor/_stream_thread.py
@@ -118,6 +118,12 @@ class StreamTask:
         self.context.currentNode = None
 
     def commit(self):
+        self.recordCollector.flush()
+        self.commitOffsets()
+
+    def commitOffsets(self):
+        """ Commit consumed offsets if needed """
+
         # may be asked to commit on rebalance or shutdown but
         # should only commit if the processor has requested.
         if self.commitOffsetNeeded:

--- a/winton_kafka_streams/processor/_stream_thread.py
+++ b/winton_kafka_streams/processor/_stream_thread.py
@@ -101,6 +101,8 @@ class StreamTask:
         self.context.currentRecord = None
         self.context.currentNode = None
 
+        return True
+
     def maybe_punctuate(self):
         timestamp = self.current_timestamp
 
@@ -274,8 +276,15 @@ class StreamThread:
             self.tasks[record.partition()].add_records([record])
 
     def process_and_punctuate(self):
-        for task in self.tasks:
-            task.process()
+        while True:
+            total_processed_each_round = 0
+
+            for task in self.tasks:
+                if task.process():
+                    total_processed_each_round += 1
+
+            if total_processed_each_round == 0:
+                break
 
         for task in self.tasks:
             task.maybe_punctuate()

--- a/winton_kafka_streams/processor/extract_timestamp.py
+++ b/winton_kafka_streams/processor/extract_timestamp.py
@@ -18,7 +18,7 @@ class RecordTimeStampExtractor(TimeStampExtractor):
 
     def extract(self, record, previous_timestamp):
         """
-        Returns wall clock time for every message
+        Returns kafka timestamp for message
 
         Parameters:
         -----------
@@ -32,7 +32,7 @@ class RecordTimeStampExtractor(TimeStampExtractor):
         time : long
             Time in seconds since the epoch
         """
-        timestamp = record.timestamp()
+        (timestamp_type, timestamp) = record.timestamp()
         if timestamp < 0:
             return self.on_error(record, timestamp, previous_timestamp)
 

--- a/winton_kafka_streams/processor/processor.py
+++ b/winton_kafka_streams/processor/processor.py
@@ -32,7 +32,7 @@ class SourceProcessor(BaseProcessor):
     def process(self, key, value):
         self.context.forward(key, value)
 
-    def punctuate(self):
+    def punctuate(self, timestamp):
         pass
 
 class SinkProcessor(BaseProcessor):
@@ -49,7 +49,7 @@ class SinkProcessor(BaseProcessor):
     def process(self, key, value):
         self._send(key, value, self.context.timestamp)
 
-    def punctuate(self):
+    def punctuate(self, timestamp):
         pass
 
     def _send(self, key, value, timestamp):

--- a/winton_kafka_streams/processor/processor_context.py
+++ b/winton_kafka_streams/processor/processor_context.py
@@ -46,3 +46,10 @@ class ProcessorContext(_context.Context):
                 child.process(key, value)
         finally:
             self.currentNode = previousNode
+
+    def schedule(self, timestamp):
+        """
+        Schedule the punctuation function call
+
+        """
+        self.task.schedule(timestamp)

--- a/winton_kafka_streams/processor/processor_context.py
+++ b/winton_kafka_streams/processor/processor_context.py
@@ -32,7 +32,7 @@ class ProcessorContext(_context.Context):
 
         """
 
-        self.task.needCommit = True
+        self.task.needCommit()
 
     def forward(self, key, value):
         """


### PR DESCRIPTION
Quite important for correctness. We need to make sure that all output has been sent before committing a message.

This has highlighted the need to process a good number of records before committing to avoid slowing everything down a whole lot, see comments below.