### PR TITLE
Improve wording of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 # Winton Kafka Streams
 
-Implementation of [Apache Kafka Streams](https://kafka.apache.org/documentation/streams/) in Python. 
+Implementation of [Apache Kafka's streams API](https://kafka.apache.org/documentation/streams/) in Python. 
 
 ## What and why?
 Apache Kafka is an open-source stream processing platform developed
 by the Apache Software Foundation written in Scala and Java. Kafka
-Streams is a Java library for building distributed stream processing
-applications using Apache Kafka. Kafka Streams does not require any
+has streams API added for building stream processing applications
+using Apache Kafka. Applications built with Kafka's streams API do not require any
 setup beyond the provision of a Kafka cluster.
 
-Winton Kafka Streams is a Python implementation of the Apache Kafka
-Streams project. It builds on Confluent's librdkafka (a high
+Winton Kafka Streams is a Python implementation of Apache Kafka's
+streams API. It builds on Confluent's librdkafka (a high
 performance C library implementing the Kafka protocol) and the
 Confluent Python Kafka library to achieve this.
 
-The power and simplicity of both Python and Kafka Streams combined
+The power and simplicity of both Python and Kafka's streams API combined
 opens the streaming model to many more people and applications.
 
 ## Getting started
@@ -47,7 +47,7 @@ are required for development only and not for running the package.
 
 Tests will run when py.test is called inside the root of the repository.
 
-## Contributing
+## Contributing
 Please see the CONTRIBUTING.md document for more details on getting involved. 
 
 ## Contact

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,11 +2,11 @@
 
 The roadmap is a high level overview of work we would like to see implemented  For more details and discussion of new features, improvements or bugs, please see the [issue list](https://github.com/wintoncode/winton-kafka-streams/issues) in GitHub. 
 
-* Complete Kafka Streams implementation in Python
+* Complete implementation of Kafka's streams API in Python
     * The current code is a good proof of concept but is still under active development. There are a number of key features remaining, in particular a persistent state store and a DSL. There are also many improvements to existing features left to implement - check the issue list for the latest status. 
-* Implement new Kafka Streams features
+* Implement new features of Kafka's streams API
     * v0.11 of Apache Kafka was released on 28 June 2017 with many important and useful features. 
 * Investigate a more Pythonic API/DSL
-    * The current Processor API follows the Java layout very closely. A Python Kafka streams domain specific language (DSL) should leverage Python's unique language stregnths to make writing a Kafka streams application as easy and intuitive as possible. 
+    * The current Processor API follows the Java layout very closely. A Python streams domain specific language (DSL) should leverage Python's unique language stregnths to make writing stream application as easy and intuitive as possible. 
 * Optimise performance
     * Python has many known performance limitations; continue to optimise the code to perform as well as possible. Consider implementing some or all of the application in C. 

--- a/examples/binning/ReadMe.md
+++ b/examples/binning/ReadMe.md
@@ -2,7 +2,7 @@
 
 ## Additional Python Package
 
-In addition to the packages required by the Kafka Streams package, you
+In addition to the packages required by the Winton Kafka Streams package, you
 will also need to have `pandas` available.  See also `live-plot.ipynb`
 for a jupyter notebook visualising this example (it additionally
 requires `jupyter` and `bokeh`).
@@ -57,7 +57,7 @@ produced 60000 values.
 
 ## Run binning
 
-Now run the Kafka Streams application that consumes the price topic:
+Now run the Winton Kafka Streams application that consumes the price topic:
 
     python -u binning.py --config-file config.properties
 

--- a/winton_kafka_streams/kafka_config.py
+++ b/winton_kafka_streams/kafka_config.py
@@ -1,5 +1,5 @@
 """
-Configuration values that may be set to control behaviour of Kafka Streams
+Configuration values that may be set to control behaviour of Winton Kafka Streams
 
 Configuration may either be set inline in your application using:
 
@@ -109,7 +109,7 @@ Importance: Medium
 VALUE_SERDE = None # TODO
 
 """
-A host:port pair pointing to an embedded user defined endpoint that can be used for discovering the locations of state stores within a single Kafka Streams application. The value of this must be different for each instance of the application.
+A host:port pair pointing to an embedded user defined endpoint that can be used for discovering the locations of state stores within a single Winton Kafka Streams application. The value of this must be different for each instance of the application.
 Default ""
 Importance: Low
 """
@@ -123,7 +123,7 @@ Importance: Low
 BUFFERED_RECORDS_PER_PARTITION = 1000
 
 """
-An id string to pass to the server when making requests. (This setting is passed to the consumer/producer clients used internally by Kafka Streams.)
+An id string to pass to the server when making requests. (This setting is passed to the consumer/producer clients used internally by Winton Kafka Streams.)
 Default: ""
 Importance: Low
 """


### PR DESCRIPTION
Make it clear that Apache Kafka is the product name and the streams implemented in Python is a Kafka API. 