### PR TITLE
Rename kafka streams

### DIFF
--- a/examples/binning/binning.py
+++ b/examples/binning/binning.py
@@ -97,7 +97,7 @@ def run(config_file = None):
             processor('binner', Binning, 'prices'). \
             sink('result', 'bin-prices', 'binner')
 
-    wks = kafka_stream.KafkaStream(topology_builder, kafka_config)
+    wks = kafka_stream.KafkaStreams(topology_builder, kafka_config)
     wks.start()
     try:
         while True:

--- a/examples/debug/example.py
+++ b/examples/debug/example.py
@@ -47,7 +47,7 @@ def _debug_run(config_file):
             sink('output-double', 'wks-debug-example-output', 'double'). \
             state_store('double-store', SimpleStore, 'double')
 
-    wks = kafka_stream.KafkaStream(topology_builder, kafka_config)
+    wks = kafka_stream.KafkaStreams(topology_builder, kafka_config)
     wks.start()
     try:
         while True:

--- a/examples/wordcount/example.py
+++ b/examples/wordcount/example.py
@@ -52,7 +52,7 @@ def run(config_file):
             processor('count', WordCount, 'input-value'). \
             sink('output-count', 'wks-wordcount-example-count', 'count')
 
-    wks = kafka_stream.KafkaStream(topology_builder, kafka_config)
+    wks = kafka_stream.KafkaStreams(topology_builder, kafka_config)
     wks.start()
     try:
         while True:

--- a/winton_kafka_streams/kafka_client_supplier.py
+++ b/winton_kafka_streams/kafka_client_supplier.py
@@ -1,0 +1,28 @@
+import logging
+import pprint
+
+import confluent_kafka as kafka
+
+log = logging.getLogger(__name__)
+
+
+class KafkaClientSupplier:
+    def __init__(self, _config):
+        self.config = _config
+
+    def consumer(self):
+        log.debug('Starting consumer...')
+        # TODO: Must set all config values applicable to a consumer
+        consumer_args = {'bootstrap.servers': self.config.BOOTSTRAP_SERVERS,
+                               'group.id': 'testgroup',
+                               'default.topic.config': {'auto.offset.reset':
+                                                        self.config.AUTO_OFFSET_RESET},
+                               'enable.auto.commit': self.config.ENABLE_AUTO_COMMIT}
+
+        log.debug('Consumer Arguments: %s', pprint.PrettyPrinter().pformat(consumer_args))
+
+        return kafka.Consumer(consumer_args)
+
+    def producer(self):
+        # TODO: Must set all config values applicable to a producer
+        return kafka.Producer({'bootstrap.servers': self.config.BOOTSTRAP_SERVERS})

--- a/winton_kafka_streams/kafka_stream.py
+++ b/winton_kafka_streams/kafka_stream.py
@@ -3,12 +3,10 @@ Primary entrypoint for applications wishing to implement Python Kafka Streams
 
 """
 
-import pprint
 import logging
 
-import confluent_kafka as kafka
-
 from .processor import StreamThread
+from .kafka_client_supplier import KafkaClientSupplier
 
 log = logging.getLogger(__name__)
 
@@ -19,35 +17,13 @@ class KafkaStream:
 
     """
 
-    class KafkaSupplier:
-        def __init__(self, _config):
-            self.config = _config
-
-        def consumer(self):
-            log.debug('Starting consumer...')
-            # TODO: Must set all config values applicable to a consumer
-            consumer_args = {'bootstrap.servers': self.config.BOOTSTRAP_SERVERS,
-                                   'group.id': 'testgroup',
-                                   'default.topic.config': {'auto.offset.reset':
-                                                            self.config.AUTO_OFFSET_RESET},
-                                   'enable.auto.commit': self.config.ENABLE_AUTO_COMMIT}
-
-            log.debug('Consumer Arguments: %s', pprint.PrettyPrinter().pformat(consumer_args))
-
-            return kafka.Consumer(consumer_args)
-
-        def producer(self):
-            # TODO: Must set all config values applicable to a producer
-            return kafka.Producer({'bootstrap.servers': self.config.BOOTSTRAP_SERVERS})
-
-
     def __init__(self, topology, kafka_config):
         self.topology = topology
         self.kafka_config = kafka_config
 
         self.consumer = None
 
-        self.stream_thread = StreamThread(topology, kafka_config, self.KafkaSupplier(self.kafka_config))
+        self.stream_thread = StreamThread(topology, kafka_config, KafkaClientSupplier(self.kafka_config))
 
     def start(self):
         self.stream_thread.start()

--- a/winton_kafka_streams/kafka_streams.py
+++ b/winton_kafka_streams/kafka_streams.py
@@ -11,7 +11,7 @@ from .kafka_client_supplier import KafkaClientSupplier
 log = logging.getLogger(__name__)
 
 
-class KafkaStream:
+class KafkaStreams:
     """
     Encapsulates stream graph processing units
 


### PR DESCRIPTION
For the sake of consistency with Java, and extract kafka_client_supplier.py.

Tiny PR, but going to touch that class now and easier to review the next PR this way.