### PR TITLE
dockerized wordcount example

### DIFF
--- a/examples/wordcount/README.md
+++ b/examples/wordcount/README.md
@@ -1,9 +1,23 @@
 # Wordcount Winton Kafka Streams Example
 
-## Running
+## Running native
 * Edit the config.properties file if necessary to change where Kafka is running
 * Run: python example.py
-* Start a console producer writing to the topic 'wks-wordcount-example-topic-two'
+* Start a console producer writing to the topic 'wks-wordcount-example-topic'
+
+##Running dockerized
+* Install docker and docker-compose
+* cd into examples/wordcount/docker
+* start the docker services with `docker-compose up -d`
+* the kafka-debug service outputs the `wks-wordcount-example-count`
+* the output should be (after a minute or so):
+    ```
+    $ docker-compose logs kafka-debug
+    ...
+    kafka-debug_1    | b	2
+    kafka-debug_1    | c	1
+    kafka-debug_1    | a	3
+    ```
 
 ## Features
 * Listens to the topic 'wks-wordcount-example-topic' and writes output to 'wks-wordcount-example-count'

--- a/examples/wordcount/docker/docker-compose.yml
+++ b/examples/wordcount/docker/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '2'
+services:
+  wordcount:
+    build:
+      context: ../../../
+      dockerfile: examples/wordcount/docker/wordcount/Dockerfile
+    volumes:
+     - ../../../:/code
+    depends_on:
+      - kafka
+  source_client:
+    build:
+      context: ../../../
+      dockerfile: examples/wordcount/docker/source_client/Dockerfile
+    volumes:
+     - ../../../:/code
+    depends_on:
+      - kafka
+  kafka:
+    image: "spotify/kafka"
+    hostname: kafka
+    ports:
+     - 2181:2181
+     - 9092:9092
+     - 7203:7203
+    environment:
+      - JMX_PORT=7203
+      - ADVERTISED_HOST=kafka
+      - ADVERTISED_PORT=9092
+  kafka-manager:
+    image: "sheepkiller/kafka-manager"
+    ports:
+     - 9000:9000
+    environment:
+     - ZK_HOSTS=kafka:2181
+     - APPLICATION_SECRET=letmein
+  kafka-debug:
+    build:
+      context: ../../../
+      dockerfile: examples/wordcount/docker/kafka-debug/Dockerfile
+    depends_on:
+      - kafka

--- a/examples/wordcount/docker/kafka-debug/Dockerfile
+++ b/examples/wordcount/docker/kafka-debug/Dockerfile
@@ -1,0 +1,18 @@
+
+FROM openjdk:8-jre
+
+ENV SCALA_VERSION 2.11
+ENV KAFKA_VERSION 0.10.1.0
+ENV KAFKA_HOME /opt/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION"
+
+# Install Kafka and other needed things
+RUN apt-get update && \
+    apt-get install -y wget dnsutils && \
+    rm -rf /var/lib/apt/lists/* && \
+    apt-get clean && \
+    wget -q http://apache.mirrors.spacedump.net/kafka/"$KAFKA_VERSION"/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION".tgz -O /tmp/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION".tgz && \
+    tar xfz /tmp/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION".tgz -C /opt && \
+    rm /tmp/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION".tgz
+
+
+CMD ["/opt/kafka_2.11-0.10.1.0/bin/kafka-console-consumer.sh","--bootstrap-server","kafka:9092","--topic","wks-wordcount-example-count","--from-beginning","--property","print.key=true"]

--- a/examples/wordcount/docker/source_client/Dockerfile
+++ b/examples/wordcount/docker/source_client/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.6
+ADD . /code
+
+RUN apt-get update
+RUN echo "/usr/local/lib" >> /etc/ld.so.conf
+RUN git clone https://github.com/edenhill/librdkafka.git /tmp/librdkafka
+RUN ls /tmp/ && cd /tmp/librdkafka && ./configure && make && make install && ldconfig
+
+WORKDIR /code/examples/wordcount/
+RUN pip --version
+#RUN pip install -e git+https://github.com/confluentinc/confluent-kafka-python.git#egg=confluent-kafka
+RUN pip install -e ../../
+
+CMD ["python", "source_client.py"]

--- a/examples/wordcount/docker/wordcount/Dockerfile
+++ b/examples/wordcount/docker/wordcount/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.6
+ADD . /code
+
+RUN apt-get update
+RUN echo "/usr/local/lib" >> /etc/ld.so.conf
+RUN git clone https://github.com/edenhill/librdkafka.git /tmp/librdkafka
+RUN ls /tmp/ && cd /tmp/librdkafka && ./configure && make && make install && ldconfig
+
+WORKDIR /code/examples/wordcount/
+RUN pip --version
+#RUN pip install -e git+https://github.com/confluentinc/confluent-kafka-python.git#egg=confluent-kafka
+RUN pip install -e ../../
+
+CMD ["python", "example.py", "-c", "docker/wordcount/config.properties"]

--- a/examples/wordcount/docker/wordcount/config.properties
+++ b/examples/wordcount/docker/wordcount/config.properties
@@ -1,0 +1,2 @@
+bootstrap.servers = kafka:9092
+auto.offset.reset = earliest

--- a/examples/wordcount/example.py
+++ b/examples/wordcount/example.py
@@ -7,11 +7,12 @@ Main entrypoints
 
 import logging
 import time
+import sys
 import collections
 
 from winton_kafka_streams.processor import BaseProcessor, TopologyBuilder
 import winton_kafka_streams.kafka_config as kafka_config
-import winton_kafka_streams.kafka_stream as kafka_stream
+import winton_kafka_streams.kafka_streams as kafka_streams
 
 log = logging.getLogger(__name__)
 
@@ -29,6 +30,7 @@ class WordCount(BaseProcessor):
 
     def process(self, key, value):
         words = value.decode('utf-8').split()
+        log.debug(f'words list ({words})')
         self.word_counts.update(words)
         self.dirty_words |= set(words)
 
@@ -45,14 +47,12 @@ def run(config_file):
 
     # Can also directly set config variables inline in Python
     #kafka_config.KEY_SERDE = MySerde
-
     with TopologyBuilder() as topology_builder:
         topology_builder. \
             source('input-value', ['wks-wordcount-example-topic']). \
             processor('count', WordCount, 'input-value'). \
             sink('output-count', 'wks-wordcount-example-count', 'count')
-
-    wks = kafka_stream.KafkaStreams(topology_builder, kafka_config)
+    wks = kafka_streams.KafkaStreams(topology_builder, kafka_config)
     wks.start()
     try:
         while True:
@@ -76,6 +76,6 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     levels = {0: logging.WARNING, 1: logging.INFO, 2: logging.DEBUG}
-    logging.basicConfig(level=levels.get(args.verbose, logging.DEBUG))
-
+    level = levels.get(args.verbose, logging.DEBUG)
+    logging.basicConfig(stream=sys.stdout, level=level)
     run(args.config_file)

--- a/examples/wordcount/source_client.py
+++ b/examples/wordcount/source_client.py
@@ -1,0 +1,10 @@
+from confluent_kafka import Producer
+
+
+p = Producer({'bootstrap.servers': 'kafka:9092'})
+topic = 'wks-wordcount-example-topic'
+some_data_source = ["a b c", "a b", "a"]
+for data in some_data_source:
+    print("producing {} to {}".format(data, topic))
+    p.produce(topic, data.encode('utf-8'))
+p.flush()


### PR DESCRIPTION
This add a docker-compose project to the wordcount example. Additionally to the native execution, the very same example can now be executed with docker in several services:
* kafka: a kafka server
* kafka-manager: a gui to see what is happening in kafka (configure the zookeeper: kafka:2181)
* wordcount: the wordcount kafka streams example app
* source_client: a trivial client which writes to kafka
* kafka-debug: a trivial consumer for the kafka output stream of the wordcount example

If you like this, one can easily dockerize the other examples and even the integration tests can be automated using docker-compose

If you have any questions, just ask, this is an early demo, I am happy to incorporate any suggestions...