### PR TITLE
Add .travis.yml and badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+dist: trusty # librdkafka support begins at Trusty.
+python:
+  - "3.6" # Advertised support
+  - "3.6-dev" # Check we'll keep working in future
+  - "nightly"
+before_install:
+  - wget -qO - http://packages.confluent.io/deb/3.2/archive.key | sudo apt-key add - # Use the confluent repository
+  - sudo add-apt-repository "deb [arch=amd64] http://packages.confluent.io/deb/3.2 stable main"
+  - sudo apt-get update -qq # Update quietly.
+  - sudo apt-get install -y librdkafka-dev librdkafka1
+install: "pip install --editable .[develop]"
+script: pytest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Winton Kafka Streams
 
-Implementation of [Apache Kafka's Streams API](https://kafka.apache.org/documentation/streams/) in Python. 
+[![Build Status](https://travis-ci.org/winton-code/winton-kafka-streams.svg?branch=master)](https://travis-ci.org/winton-code/winton-kafka-streams)
+
+Implementation of [Apache Kafka's Streams API](https://kafka.apache.org/documentation/streams/) in Python.
 
 ## What and why?
 Apache Kafka is an open-source stream processing platform developed
@@ -24,13 +26,13 @@ The minimum Python version is currently 3.6 and a working Kafka
 cluster (a single replica is sufficient for testing) are required.
 
 Confluent Python Kafka is also required and it should install
-as a dependency by pip. If it fails during installation, 
-then we recommend installing librdkafka with HomeBrew and setting 
+as a dependency by pip. If it fails during installation,
+then we recommend installing librdkafka with HomeBrew and setting
 `CFLAGS=-I/usr/local/include` and `LDFLAGS=-L/usr/local/lib` is
-recommended. 
+recommended.
 
 Cloning the Winton Kafka Streams repository from GitHub is
-recommended if you want to contribute to the project. Use: 
+recommended if you want to contribute to the project. Use:
 `pip install --editable <path/to/winton_kafka_streams>[develop]`
 to install as an editable workspace with additional dependencies
 required for development.
@@ -54,7 +56,7 @@ packages. Install these with the command:
 pip install <path/to/winton_kafka_streams>[binning_example]
 
 ## Contributing
-Please see the CONTRIBUTING.md document for more details on getting involved. 
+Please see the CONTRIBUTING.md document for more details on getting involved.
 
 ## Contact
  - GitHub: https://github.com/wintoncode/


### PR DESCRIPTION
.travis.yml allows us to run tests automatically. To work this needs to be
enabled by a Travis administrator.

We use the Confluent librdkafka and run just the tests, not the examples.

Tests pass on my fork here: https://travis-ci.org/ElliotJH/winton-kafka-streams/builds/254948950