### PR TITLE
Fix pep8 newlines and typos

### DIFF
--- a/tests/processor/test_base_processor.py
+++ b/tests/processor/test_base_processor.py
@@ -6,8 +6,10 @@ custom processor implementations
 import winton_kafka_streams.processor as wks_processor
 from winton_kafka_streams.processor.processor_context import ProcessorContext
 
+
 def test_createBaseProcessor():
     wks_processor.BaseProcessor()
+
 
 def test_initialiseBaseProcessor():
     mock_context = ProcessorContext(None, None, {})

--- a/tests/processor/test_extract_timestamp.py
+++ b/tests/processor/test_extract_timestamp.py
@@ -12,9 +12,11 @@ expected_time = 1496735099.23712
 error_time_offset = 1000
 timestamp_create_time = 1
 
+
 class TestRecordTimeStampExtractorImpl(wks_processor.RecordTimeStampExtractor):
     def on_error(self, record, timestamp, previous_timestamp):
         return timestamp - 1000
+
 
 class MockRecord:
     def __init__(self, time):
@@ -23,12 +25,15 @@ class MockRecord:
     def timestamp(self):
         return (timestamp_create_time, self.time)
 
+
 def test_RecordTimeStampExtractorNoImpl():
     pytest.raises(TypeError, wks_processor.RecordTimeStampExtractor)
+
 
 def test_RecordTimeStampExtractor():
     rtse = TestRecordTimeStampExtractorImpl()
     assert rtse.extract(MockRecord(expected_time), expected_time-12345) == expected_time
+
 
 def test_InvalidRecordTimeStampExtractorNoImpl():
     rtse = TestRecordTimeStampExtractorImpl()

--- a/tests/processor/test_punctuation_queue.py
+++ b/tests/processor/test_punctuation_queue.py
@@ -1,5 +1,5 @@
-
 import winton_kafka_streams.processor._punctuation_queue as punctuation_queue
+
 
 def test_punctuation_queue():
     punctuations = []

--- a/tests/processor/test_serde.py
+++ b/tests/processor/test_serde.py
@@ -5,6 +5,7 @@ Test of all serde classes
 
 import winton_kafka_streams.processor.serde.identity as identity
 
+
 def test_identitySerde():
     ident_serde = identity.IdentitySerde()
     assert ident_serde.serialise(123) == 123

--- a/tests/processor/test_sink_processor.py
+++ b/tests/processor/test_sink_processor.py
@@ -12,9 +12,11 @@ _expected_timestamp = 1234567890
 def test_createSinkProcessorObject():
     wks_processor.SinkProcessor('topic1')
 
+
 def test_sinkProcessorTopic():
     sink = wks_processor.SinkProcessor('topic1')
     assert sink.topic == 'topic1'
+
 
 def test_sinkProcessorProcess():
 

--- a/tests/processor/test_source_processor.py
+++ b/tests/processor/test_source_processor.py
@@ -4,8 +4,10 @@ Test of source processor behaviour
 
 import winton_kafka_streams.processor as wks_processor
 
+
 def test_createSourceProcessorObject():
     wks_processor.SourceProcessor(['test-topic-name'])
+
 
 def test_sourceProcessorTopic():
     sp1 = wks_processor.SourceProcessor(('topic1',))

--- a/tests/processor/test_topology.py
+++ b/tests/processor/test_topology.py
@@ -11,9 +11,9 @@ import winton_kafka_streams._error as wks_error
 import winton_kafka_streams.processor as wks_processor
 import winton_kafka_streams.state as wks_state
 
+
 def test_createTopologyBuilder():
     wks_processor.topology.TopologyBuilder()
-
 
 
 class MyTestProcessor(wks_processor.processor.BaseProcessor):

--- a/tests/processor/test_wallclock_timestamp.py
+++ b/tests/processor/test_wallclock_timestamp.py
@@ -9,6 +9,7 @@ import winton_kafka_streams.processor.wallclock_timestamp as wallclock_timestamp
 
 expected_time = 1496735099.23712
 
+
 def test_WallClockTimeStampExtractor():
     with mock.patch('time.time', return_value=expected_time):
         assert wallclock_timestamp.WallClockTimeStampExtractor().extract(None, expected_time-1) == expected_time

--- a/winton_kafka_streams/_error.py
+++ b/winton_kafka_streams/_error.py
@@ -3,5 +3,6 @@ Run time exception thrown by winton kafka streams on error
 
 """
 
+
 class KafkaStreamsError(RuntimeError):
     pass

--- a/winton_kafka_streams/processor/_context.py
+++ b/winton_kafka_streams/processor/_context.py
@@ -10,6 +10,7 @@ from .._error import KafkaStreamsError
 
 log = logging.getLogger(__name__)
 
+
 def _raiseIfNullRecord(fn):
     @functools.wraps(fn)
     def _inner(*args, **kwargs):
@@ -17,6 +18,8 @@ def _raiseIfNullRecord(fn):
             raise KafkaStreamsError(f"Record cannot be unset when retrieving {fn.__name__}")
         return fn(*args, **kwargs)
     return _inner
+
+
 class Context:
     """
     Processor context object
@@ -71,9 +74,9 @@ class Context:
         # TODO: Need to check for a global state here
         #       This is the reason that processors access store through context
 
-        if not name in self.currentNode.state_stores:
+        if name not in self.currentNode.state_stores:
             raise KafkaStreamsError(f"Processor {currentNode.name} does not have access to store {name}")
-        if not name in self._state_stores:
+        if name not in self._state_stores:
             raise KafkaStreamsError(f"Store {name} is not found")
 
         return self._state_stores[name]

--- a/winton_kafka_streams/processor/_stream_task.py
+++ b/winton_kafka_streams/processor/_stream_task.py
@@ -9,7 +9,6 @@ from ._punctuation_queue import PunctuationQueue
 from .wallclock_timestamp import WallClockTimeStampExtractor
 
 
-
 class DummyRecord:
     """
     Dummy implementation of Record that provides the minimum needed

--- a/winton_kafka_streams/processor/_stream_thread.py
+++ b/winton_kafka_streams/processor/_stream_thread.py
@@ -75,7 +75,6 @@ class StreamThread:
         def __str__(self):
             return self.name
 
-
     def __init__(self, _topology, _config, _kafka_supplier):
         super().__init__()
         self.topology = _topology
@@ -160,7 +159,6 @@ class StreamThread:
 
         return records
 
-
     def add_records_to_tasks(self, records):
         for record in records:
             self.tasks[record.partition()].add_records([record])
@@ -186,7 +184,7 @@ class StreamThread:
             self.log.debug('Commit task "%s"', task)
             task.commit()
         except CommitFailedException as cfe:
-            self.log.warn('Failed to commit')
+            self.log.warning('Failed to commit')
             self.log.exception(cfe)
             pass
         except KafkaException as ke:

--- a/winton_kafka_streams/processor/_timestamp.py
+++ b/winton_kafka_streams/processor/_timestamp.py
@@ -5,6 +5,7 @@ Base class for all timestamp extractors
 
 import abc
 
+
 class TimeStampExtractor(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def extract(self, record, previous_timestamp):

--- a/winton_kafka_streams/processor/extract_timestamp.py
+++ b/winton_kafka_streams/processor/extract_timestamp.py
@@ -4,9 +4,9 @@ Time extractor from the message being processed
 """
 
 import abc
-import time
 
 from ._timestamp import TimeStampExtractor
+
 
 class RecordTimeStampExtractor(TimeStampExtractor):
     """

--- a/winton_kafka_streams/processor/processor.py
+++ b/winton_kafka_streams/processor/processor.py
@@ -7,6 +7,7 @@ import logging
 
 log = logging.getLogger(__name__)
 
+
 class BaseProcessor:
     def __init__(self):
         super().__init__()
@@ -17,6 +18,7 @@ class BaseProcessor:
     def initialise(self, _name, _context):
         self.name = _name
         self.context = _context
+
 
 class SourceProcessor(BaseProcessor):
     """
@@ -34,6 +36,7 @@ class SourceProcessor(BaseProcessor):
 
     def punctuate(self, timestamp):
         pass
+
 
 class SinkProcessor(BaseProcessor):
     """

--- a/winton_kafka_streams/processor/processor_context.py
+++ b/winton_kafka_streams/processor/processor_context.py
@@ -8,6 +8,7 @@ from . import _context
 
 log = logging.getLogger(__name__)
 
+
 class ProcessorContext(_context.Context):
     """
     The same processor context is shared betwen all nodes in

--- a/winton_kafka_streams/processor/serde/_base.py
+++ b/winton_kafka_streams/processor/serde/_base.py
@@ -5,6 +5,7 @@ Base class for serde implementations
 
 import abc
 
+
 class BaseSerde(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def serialise(self, value):

--- a/winton_kafka_streams/processor/serde/identity.py
+++ b/winton_kafka_streams/processor/serde/identity.py
@@ -3,6 +3,7 @@ Identity serialiser (default)
 
 """
 
+
 class IdentitySerde:
     """
     Identity serialiser that makes no changes to values

--- a/winton_kafka_streams/processor/topology.py
+++ b/winton_kafka_streams/processor/topology.py
@@ -10,6 +10,7 @@ from .._error import KafkaStreamsError
 
 log = logging.getLogger(__name__)
 
+
 class ProcessorNode:
     def __init__(self, name, processor):
         self.name = name
@@ -32,7 +33,7 @@ class ProcessorNode:
 
 class Topology:
     """
-    A realised instance of a toplogy
+    A realised instance of a topology
 
     """
     def __init__(self, sources, processors, sinks, state_stores):
@@ -123,6 +124,7 @@ class TopologyBuilder:
 
         def build_store():
             return store_type(store_name), processors
+
         def _name():
             return store_name
         build_store.name = _name

--- a/winton_kafka_streams/processor/wallclock_timestamp.py
+++ b/winton_kafka_streams/processor/wallclock_timestamp.py
@@ -7,6 +7,7 @@ import time
 
 from ._timestamp import TimeStampExtractor
 
+
 class WallClockTimeStampExtractor(TimeStampExtractor):
     """
     Time stamp extractor that returns wall clock time at the point

--- a/winton_kafka_streams/state/_abc.py
+++ b/winton_kafka_streams/state/_abc.py
@@ -6,6 +6,7 @@ Abstract classes for implementations of state classes
 import abc
 import collections.abc
 
+
 class StoreBase(collections.abc.Iterator):
     """
     Interface that must be implemented by all state classes

--- a/winton_kafka_streams/state/simple.py
+++ b/winton_kafka_streams/state/simple.py
@@ -9,6 +9,7 @@ import queue
 
 from ._abc import StoreBase
 
+
 class SimpleStore(StoreBase):
     """
     State class that holds all transform calculations in a simple array
@@ -38,8 +39,10 @@ class SimpleStore(StoreBase):
         class _IterSimpleStore:
             def __init__(self, _simple_store):
                 self.store = _simple_store
+
             def __iter__(self):
                 return self
+
             def __next__(self):
                 if self.store.values.empty():
                     raise StopIteration


### PR DESCRIPTION
Tiny PR to get started again - fix a number of pep8 warning around newlines before classes/functions.