### PR TITLE
Extract TaskId into a class

### DIFF
--- a/tests/processor/test_task_id.py
+++ b/tests/processor/test_task_id.py
@@ -1,0 +1,14 @@
+from winton_kafka_streams.processor.task_id import TaskId
+
+
+def test_taskId():
+    task_id = TaskId('group1', 0)
+
+    assert task_id == TaskId('group1', 0)
+    assert not (task_id != TaskId('group1', 0))
+    assert task_id != TaskId('group1', 1)
+    assert task_id != TaskId('group2', 0)
+
+    assert repr(task_id) == 'group1_0'
+
+    assert hash(task_id) == hash(TaskId('group1', 0))

--- a/winton_kafka_streams/processor/_stream_thread.py
+++ b/winton_kafka_streams/processor/_stream_thread.py
@@ -9,6 +9,7 @@ from enum import Enum
 
 from confluent_kafka import KafkaError
 
+from .task_id import TaskId
 from ._stream_task import StreamTask
 
 
@@ -200,7 +201,7 @@ class StreamThread:
 
     def add_stream_tasks(self, assignment):
         # simplistic, but good enough for now. should take co-locating topics etc. into account in the future
-        grouped_tasks = {f'{topic_partition.topic}_{topic_partition.partition}': {topic_partition}
+        grouped_tasks = {TaskId(topic_partition.topic, topic_partition.partition): {topic_partition}
                          for topic_partition in assignment}
         self.tasks = [StreamTask(task_id, self.config.APPLICATION_ID,
                                  partitions, self.topology, self.consumer,

--- a/winton_kafka_streams/processor/task_id.py
+++ b/winton_kafka_streams/processor/task_id.py
@@ -1,0 +1,18 @@
+class TaskId:
+    def __init__(self, topic_group_id, partition):
+        self.topic_group_id = topic_group_id
+        self.partition = partition
+
+    def __repr__(self):
+        return f"{self.topic_group_id}_{self.partition}"
+
+    def __eq__(self, other):
+        if other.__class__ is self.__class__:
+            return (self.topic_group_id, self.partition) == (other.topic_group_id, other.partition)
+        return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash((self.topic_group_id, self.partition))


### PR DESCRIPTION
Tiny step towards state support.

Implements TaskId as a proper class instead of using just a string, so we can then later access `task_id.partition`.