### PR TITLE
Use topology builder to pass in state store to wordcount example

### DIFF
--- a/tests/state/test_in_memory_key_value_store.py
+++ b/tests/state/test_in_memory_key_value_store.py
@@ -1,3 +1,4 @@
+import pytest
 from winton_kafka_streams.state.in_memory_key_value_store import InMemoryKeyValueStore
 
 
@@ -9,3 +10,8 @@ def test_inMemoryKeyValueStore():
 
     store['a'] = 2
     assert store['a'] == 2
+
+    del store['a']
+    assert store.get('a') is None
+    with pytest.raises(KeyError):
+        store['a']

--- a/tests/state/test_in_memory_key_value_store.py
+++ b/tests/state/test_in_memory_key_value_store.py
@@ -1,0 +1,11 @@
+from winton_kafka_streams.state.in_memory_key_value_store import InMemoryKeyValueStore
+
+
+def test_inMemoryKeyValueStore():
+    store = InMemoryKeyValueStore('teststore')
+
+    store['a'] = 1
+    assert store['a'] == 1
+
+    store['a'] = 2
+    assert store['a'] == 2

--- a/winton_kafka_streams/processor/topology.py
+++ b/winton_kafka_streams/processor/topology.py
@@ -123,6 +123,7 @@ class TopologyBuilder:
             raise KafkaStreamsError(f"Store with name {store.name} already exists")
 
         def build_store():
+            log.debug(f'TopologyBuilder is building state store {store_name}')
             return store_type(store_name), processors
 
         def _name():

--- a/winton_kafka_streams/state/__init__.py
+++ b/winton_kafka_streams/state/__init__.py
@@ -4,3 +4,4 @@ import state will import all possible pre-defined state classes
 """
 
 from .simple import SimpleStore
+from .in_memory_key_value_store import InMemoryKeyValueStore

--- a/winton_kafka_streams/state/in_memory_key_value_store.py
+++ b/winton_kafka_streams/state/in_memory_key_value_store.py
@@ -1,0 +1,18 @@
+class InMemoryKeyValueStore:
+    def __init__(self, name):
+        self.name = name
+        self.dict = {}
+
+    def __setitem__(self, key, value):
+        self.dict[key] = value
+
+    def __getitem__(self, key):
+        return self.dict[key]
+
+    def get(self, key, default=None):
+        return self.dict.get(key, default)
+
+    def __delitem__(self, key):
+        v = self.dict[key]
+        del self.dict[key]
+        return v


### PR DESCRIPTION
One tiny step closer towards proper state support - instantiate the state used by the wordcount example with the topology builder.

This lets us then later inject a different state store implementation, for example one that logs state changes to a topic.