### PR TITLE
Implement basic state change logging to kafka topic

### DIFF
--- a/examples/wordcount/config.properties
+++ b/examples/wordcount/config.properties
@@ -1,3 +1,4 @@
+application.id = wordcount-example
 bootstrap.servers = localhost:9092
 auto.offset.reset = earliest
 value.serde = winton_kafka_streams.processor.serialization.serdes.BytesSerde

--- a/tests/processor/test_base_processor.py
+++ b/tests/processor/test_base_processor.py
@@ -3,8 +3,11 @@ Test the base processor - base class to all
 custom processor implementations
 """
 
+import unittest.mock as mock
+
 import winton_kafka_streams.processor as wks_processor
 from winton_kafka_streams.processor.processor_context import ProcessorContext
+from winton_kafka_streams.processor.task_id import TaskId
 
 
 def test_createBaseProcessor():
@@ -12,7 +15,10 @@ def test_createBaseProcessor():
 
 
 def test_initialiseBaseProcessor():
-    mock_context = ProcessorContext(None, None, {})
+    mock_task = mock.Mock()
+    mock_task.application_id = 'test_id'
+    mock_task_id = TaskId('test_group', 0)
+    mock_context = ProcessorContext(mock_task_id, mock_task, None, {})
     bp = wks_processor.BaseProcessor()
     bp.initialise('my-name', mock_context)
 

--- a/tests/processor/test_sink_processor.py
+++ b/tests/processor/test_sink_processor.py
@@ -5,6 +5,7 @@ Test of sink processor behaviour
 import unittest.mock as mock
 
 import winton_kafka_streams.processor as wks_processor
+from winton_kafka_streams.processor.task_id import TaskId
 
 _expected_timestamp = 1234567890
 
@@ -22,7 +23,10 @@ def test_sinkProcessorProcess():
 
     with mock.patch('winton_kafka_streams.processor.ProcessorContext.timestamp', new_callable=mock.PropertyMock) as mock_timestamp:
         mock_timestamp.return_value = _expected_timestamp
-        processor_context = wks_processor.ProcessorContext(None, None, {})
+        mock_task = mock.Mock()
+        mock_task.application_id = 'test_id'
+        mock_task_id = TaskId('test_group', 0)
+        processor_context = wks_processor.ProcessorContext(mock_task_id, mock_task, None, {})
         processor_context.recordCollector = mock.MagicMock()
 
         sink = wks_processor.SinkProcessor('topic1')

--- a/winton_kafka_streams/processor/_stream_task.py
+++ b/winton_kafka_streams/processor/_stream_task.py
@@ -66,7 +66,13 @@ class StreamTask:
         self.commitOffsetNeeded = False
         self.consumedOffsets = {}
 
+        self._init_state_stores()
         self._init_topology(self.context)
+
+    def _init_state_stores(self):
+        self.log.debug(f'Initialising state stores')
+        for store in self.topology.state_stores.values():
+            store.initialise(self.context, store)
 
     def _init_topology(self, context):
         for node in self.topology.nodes.values():

--- a/winton_kafka_streams/processor/_stream_task.py
+++ b/winton_kafka_streams/processor/_stream_task.py
@@ -56,7 +56,8 @@ class StreamTask:
         self.recordCollector = RecordCollector(self.producer, self.key_serde, self.value_serde)
 
         self.queue = queue.Queue()
-        self.context = ProcessorContext(self, self.recordCollector, self.topology.state_stores)
+        self.context = ProcessorContext(self.task_id, self,
+                self.recordCollector, self.topology.state_stores)
 
         self.punctuation_queue = PunctuationQueue(self.punctuate)
         self.timestamp_extractor = WallClockTimeStampExtractor()

--- a/winton_kafka_streams/processor/processor_context.py
+++ b/winton_kafka_streams/processor/processor_context.py
@@ -16,10 +16,12 @@ class ProcessorContext(_context.Context):
     values to downstream processors.
 
     """
-    def __init__(self, _task, _recordCollector, _state_stores):
+    def __init__(self, _task_id, _task, _recordCollector, _state_stores):
 
         super().__init__(_state_stores)
 
+        self.application_id = _task.application_id
+        self.task_id = _task_id
         self.task = _task
         self.recordCollector = _recordCollector
 

--- a/winton_kafka_streams/state/__init__.py
+++ b/winton_kafka_streams/state/__init__.py
@@ -5,3 +5,4 @@ import state will import all possible pre-defined state classes
 
 from .simple import SimpleStore
 from .in_memory_key_value_store import InMemoryKeyValueStore
+from .change_logging_key_value_store import ChangeLoggingKeyValueStore

--- a/winton_kafka_streams/state/change_logging_key_value_store.py
+++ b/winton_kafka_streams/state/change_logging_key_value_store.py
@@ -23,7 +23,7 @@ class ChangeLoggingKeyValueStore:
         return self.inner.get(key, default)
 
 
-    def __delitem_(self, key):
+    def __delitem__(self, key):
         v = self.inner.__delitem__(key)
         self.change_logger.log_change(key, None)
         return v

--- a/winton_kafka_streams/state/change_logging_key_value_store.py
+++ b/winton_kafka_streams/state/change_logging_key_value_store.py
@@ -1,0 +1,29 @@
+from .store_change_logger import StoreChangeLogger
+
+class ChangeLoggingKeyValueStore:
+    def __init__(self, name, inner):
+        self.inner = inner(name)
+
+
+    def initialise(self, context, root):
+        self.inner.initialise(context, root)
+        self.change_logger = StoreChangeLogger(self.inner.name, context)
+
+
+    def __setitem__(self, key, value):
+        self.inner.__setitem__(key, value)
+        self.change_logger.log_change(key, value)
+
+
+    def __getitem__(self, key):
+        return self.inner.__getitem__(key)
+
+
+    def get(self, key, default=None):
+        return self.inner.get(key, default)
+
+
+    def __delitem_(self, key):
+        v = self.inner.__delitem__(key)
+        self.change_logger.log_change(key, None)
+        return v

--- a/winton_kafka_streams/state/in_memory_key_value_store.py
+++ b/winton_kafka_streams/state/in_memory_key_value_store.py
@@ -5,6 +5,7 @@ class InMemoryKeyValueStore:
 
     def initialise(self, context, root):
         pass
+        # TODO: register with context, passing restore callback
 
     def __setitem__(self, key, value):
         self.dict[key] = value

--- a/winton_kafka_streams/state/in_memory_key_value_store.py
+++ b/winton_kafka_streams/state/in_memory_key_value_store.py
@@ -5,7 +5,6 @@ class InMemoryKeyValueStore:
 
     def initialise(self, context, root):
         pass
-        # TODO: register with context, passing restore callback
 
     def __setitem__(self, key, value):
         self.dict[key] = value

--- a/winton_kafka_streams/state/in_memory_key_value_store.py
+++ b/winton_kafka_streams/state/in_memory_key_value_store.py
@@ -3,6 +3,10 @@ class InMemoryKeyValueStore:
         self.name = name
         self.dict = {}
 
+    def initialise(self, context, root):
+        pass
+        # TODO: register with context, passing restore callback
+
     def __setitem__(self, key, value):
         self.dict[key] = value
 

--- a/winton_kafka_streams/state/store_change_logger.py
+++ b/winton_kafka_streams/state/store_change_logger.py
@@ -1,0 +1,11 @@
+class StoreChangeLogger:
+    def __init__(self, store_name, context):
+        self.topic = f'{context.application_id}-{store_name}-changelog'
+        self.context = context
+        self.partition = context.task_id.partition;
+        self.record_collector = context.recordCollector
+
+    def log_change(self, key, value):
+        if self.record_collector:
+            self.record_collector.send(self.topic, key, value,
+                    self.context.timestamp, partition=self.partition)


### PR DESCRIPTION
Implements basic change logging of state store modifications to a topic.

Once we have this, we "only" need to read them back in and then we should have simple persistent state.