### PR TITLE
Fix punctuate with same timestamp

### DIFF
--- a/tests/processor/test_punctuation_queue.py
+++ b/tests/processor/test_punctuation_queue.py
@@ -23,3 +23,10 @@ def test_punctuation_queue():
     assert len(punctuations) == 2
 
     assert punctuations == [('node', 0), ('node', 100)]
+
+
+def test_punctuation_schedule_can_compare_entires_with_same_timestamp():
+    schedule1 = punctuation_queue.PunctuationSchedule(123, {}, 100)
+    schedule2 = punctuation_queue.PunctuationSchedule(123, {}, 100)
+
+    assert not schedule1 < schedule2

--- a/winton_kafka_streams/processor/_punctuation_queue.py
+++ b/winton_kafka_streams/processor/_punctuation_queue.py
@@ -2,7 +2,9 @@ from queue import PriorityQueue
 from collections import namedtuple
 
 
-PunctuationSchedule = namedtuple('PunctuationSchedule', ['timestamp', 'node', 'interval'])
+class PunctuationSchedule(namedtuple('PunctuationSchedule', ['timestamp', 'node', 'interval'])):
+    def __lt__(self, other):
+        return self.timestamp < other.timestamp
 
 
 class PunctuationQueue:


### PR DESCRIPTION
Fixes https://github.com/wintoncode/winton-kafka-streams/issues/37.

Inserting into the priority queue orders the PunctuationSchedule
objects, which resulted in a comparison between ProcessorNodes if the
timestamps were equal.

Explicitly implement comparison between PunctuationSchedules, leaving
order of punctuation at the same timestamp undefined and comparing only by timestamp.

This matches Java, https://github.com/apache/kafka/blob/trunk/streams/src/main/java/org/apache/kafka/streams/processor/internals/PunctuationSchedule.java via https://github.com/apache/kafka/blob/trunk/streams/src/main/java/org/apache/kafka/streams/processor/internals/Stamped.java