### PR TITLE
Use commit asynchronous for python 3.7 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('README.md') as readme_file:
 
 requirements = [
     'javaproperties',
-    'confluent-kafka',
+    'confluent-kafka>=0.11.4',
     'requests',
     'avro-python3'
 ]

--- a/winton_kafka_streams/processor/_stream_task.py
+++ b/winton_kafka_streams/processor/_stream_task.py
@@ -159,7 +159,7 @@ class StreamTask:
         try:
             if self.commitOffsetNeeded:
                 offsets_to_commit = [TopicPartition(t, p, o + 1) for ((t, p), o) in self.consumedOffsets.items()]
-                self.consumer.commit(offsets=offsets_to_commit, async=False)
+                self.consumer.commit(offsets=offsets_to_commit, asynchronous=False)
                 self.consumedOffsets.clear()
                 self.commitOffsetNeeded = False
 


### PR DESCRIPTION
`confluent_kafka_python` 0.11.4 was just released. which should fix our CI build for Python 3.7 (which made `async` a keyword).

Might need to wait until the official packages are up on PyPi for this to build.

Closes #48.