### PR TITLE
timestamp not always integer causing crash. Now checks common cases.

### DIFF
--- a/winton_kafka_streams/processor/_record_collector.py
+++ b/winton_kafka_streams/processor/_record_collector.py
@@ -35,6 +35,10 @@ class RecordCollector:
 
         while not produced:
             try:
+                if isinstance(timestamp, tuple) and timestamp:
+                    timestamp = timestamp[-1]
+                if isinstance(timestamp, float):
+                    timestamp = int(timestamp)
                 self.producer.produce(topic, ser_value, ser_key, partition, self.on_delivery, partitioner, timestamp)
                 self.producer.poll(0)  # Ensure previous message's delivery reports are served
                 produced = True


### PR DESCRIPTION
Noticed that the timestamp is not always passed correctly to producer.produce(). This is only a quick fix, but perhaps the root of the problem should be investigated.